### PR TITLE
Fixing link to public keys

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -158,7 +158,7 @@
 &quot;88P&quot;&quot;Y88P'   8I   `Y8  88P&quot;&quot;Y8888P     `Y8888P&quot;Y888  8&quot;    &quot;Y8P&quot;   P&quot;Y888P&quot;   8P&quot;&quot;Y8P&quot;Y8888P&quot;`Y8</pre></td>
               </tr>
             </thead>
-            <tr><td><pre id="whoo"><a href="https://blog.patternsinthevoid.net/index.html">BLOG</a>  |  <a href="https://blog.patternsinthevoid/isis.txt" title="">PUBLIC KEYS</a>  |  <a href="https://code.ciph.re/isis">CODE</a></pre></td></tr>
+            <tr><td><pre id="whoo"><a href="https://blog.patternsinthevoid.net/index.html">BLOG</a>  |  <a href="https://blog.patternsinthevoid.net/isis.txt" title="">PUBLIC KEYS</a>  |  <a href="https://code.ciph.re/isis">CODE</a></pre></td></tr>
             <tr><td><table><tr><td><pre>    _______________________________________________________
    |                                                       |
    | i sorry. i no understand. y u no make total destroy?  |


### PR DESCRIPTION
Looks like you dropped a part of the domain name when rearranging the header:

https://github.com/isislovecruft/patternsinthevoid/commit/8b7e569570375b50798313abf8ad9524fab6dc30#diff-30d3aca3ddbd02ee548c917dcf5666bcR161